### PR TITLE
Typo: Xcode

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-## ![eppz!tools](http://www.eppz.eu/beacons/eppz!.png) eppz!xCode
+## ![eppz!tools](http://www.eppz.eu/beacons/eppz!.png) eppz!Xcode
 
 #### Colors with a sense
 
 Color are built upon a distinctive set of base colors, applied some slight modifiers to subcategories, topped with some emphasizes added to mark code origins.
 
-![eppz! xCode color scheme design process](https://raw.github.com/eppz/eppz-xCode/design/eppz!xCode_color_scheme_process.gif)
+![eppz! Xcode color scheme design process](https://raw.github.com/eppz/eppz-Xcode/design/eppz!xCode_color_scheme_process.gif)
 
 Expression categories are distributed along color wheel.
 + Classes, type names are yellowish
@@ -15,18 +15,18 @@ Expression categories are distributed along color wheel.
 Your classes are brighter
 + Framework Class-, method-, variable colors are a bit weakened (35%) to emphasize your code more
 
-![eppz! xCode color scheme preview](https://raw.github.com/eppz/eppz-xCode/design/eppz!xCode_color_scheme_preview.png)
-![eppz! xCode color scheme preview](https://raw.github.com/eppz/eppz-xCode/design/_previews/eppz!xCode_color_scheme_declarations.jpg)
+![eppz! Xcode color scheme preview](https://raw.github.com/eppz/eppz-Xcode/design/eppz!xCode_color_scheme_preview.png)
+![eppz! Xcode color scheme preview](https://raw.github.com/eppz/eppz-Xcode/design/_previews/eppz!xCode_color_scheme_declarations.jpg)
 
 Design files located in `design` branch.
 
-**Donate eppz!xCode** by <a href="https://twitter.com/intent/tweet?text=%23xCode%20color%20scheme%20with%20sense%20https%3A%2F%2Fgithub.com%2Feppz%2Feppz-xCode%20%20%40_eppz%20%23iosdev%20%23code%20%23tool%20%23workflow%20pic.twitter.com%2Fh8HHyfVEAB"><img src="http://eppz.eu/beacons/eppz!_tweet.png" align="absmiddle"></a> this or follow <a href="https://twitter.com/intent/user?original_referer=https%3A%2F%2Ftwitter.com%2Fabout%2Fresources%2Fbuttons&region=following&screen_name=_eppz&tw_p=followbutton&variant=2.0"><img src="http://eppz.eu/beacons/eppz!_follow.png" align="absmiddle"></a>
+**Donate eppz!Xcode** by <a href="https://twitter.com/intent/tweet?text=%23xCode%20color%20scheme%20with%20sense%20https%3A%2F%2Fgithub.com%2Feppz%2Feppz-xCode%20%20%40_eppz%20%23iosdev%20%23code%20%23tool%20%23workflow%20pic.twitter.com%2Fh8HHyfVEAB"><img src="http://eppz.eu/beacons/eppz!_tweet.png" align="absmiddle"></a> this or follow <a href="https://twitter.com/intent/user?original_referer=https%3A%2F%2Ftwitter.com%2Fabout%2Fresources%2Fbuttons&region=following&screen_name=_eppz&tw_p=followbutton&variant=2.0"><img src="http://eppz.eu/beacons/eppz!_follow.png" align="absmiddle"></a>
 
 #### Usage
-Clone to `~/Library/Developer/Xcode/UserData/FontAndColorThemes/` (create folder if not exist already), then restart xCode. Or simply grab from [Alcatraz](http://alcatraz.io) package manager.
+Clone to `~/Library/Developer/Xcode/UserData/FontAndColorThemes/` (create folder if not exist already), then restart Xcode. Or simply grab from [Alcatraz](http://alcatraz.io) package manager.
 
 #### License
-> Licensed under the [Open Source MIT license](http://en.wikipedia.org/wiki/MIT_License).
+> Licensed under the [Open Source MIT license](https://en.wikipedia.org/wiki/MIT_License).
 
 
 [![Bitdeli Badge](https://d2weczhvl823v0.cloudfront.net/eppz/eppz-xcode/trend.png)](https://bitdeli.com/free "Bitdeli Badge")


### PR DESCRIPTION
In the past 10 years, Apple has always been using the capitalization "Xcode": https://web.archive.org/web/20081006233046/http://developer.apple.com/technology/tools.html